### PR TITLE
Fix missing imports and typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# mailable-C2-framework-in-Python
+# malleable-C2-framework-in-Python
 still working through this 

--- a/clientside.py
+++ b/clientside.py
@@ -2,6 +2,7 @@
 
 from flask import Flask, request
 import subprocess
+import requests
 
 app = Flask(__name__)
 

--- a/email_exfil.py
+++ b/email_exfil.py
@@ -2,6 +2,8 @@
 
 import zipfile
 import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.application import MIMEApplication
 
 # Compress the client component files into a ZIP archive
 with zipfile.ZipFile('client_component.zip', 'w') as zip:


### PR DESCRIPTION
## Summary
- fix README project name
- add missing requests import to clientside
- add missing email mime imports

## Testing
- `python -m py_compile clientside.py email_exfil.py servercomp.py simple_UI.py`